### PR TITLE
CommadTargetType enum

### DIFF
--- a/src/Discord.Net.Interactions/Entities/CommandTargetType.cs
+++ b/src/Discord.Net.Interactions/Entities/CommandTargetType.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Discord.Interactions
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    [Flags]
+    public enum CommandTargetType
+    {
+        None = 0x00,
+        SlashCommand = 0x1,
+        MessageCommand = 0x2,
+        UserCommand = 0x4,
+        ButtonInteraction = 0x8,
+        SelectMenuInteraction = 0x10,
+        ModalInteraction = 0x20,
+        AutocompleteInteraction = 0x40
+    }
+}

--- a/src/Discord.Net.Interactions/Info/Commands/AutocompleteCommandInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Commands/AutocompleteCommandInfo.cs
@@ -12,6 +12,9 @@ namespace Discord.Interactions
     /// </summary>
     public sealed class AutocompleteCommandInfo : CommandInfo<CommandParameterInfo>
     {
+        /// <inheritdoc/>
+        public override CommandTargetType CommandTargetType => CommandTargetType.AutocompleteInteraction;
+
         /// <summary>
         ///     Gets the name of the target parameter.
         /// </summary>

--- a/src/Discord.Net.Interactions/Info/Commands/CommandInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Commands/CommandInfo.cs
@@ -53,6 +53,9 @@ namespace Discord.Interactions
         public bool IsTopLevelCommand { get; }
 
         /// <inheritdoc/>
+        public abstract CommandTargetType CommandTargetType { get; }
+
+        /// <inheritdoc/>
         public RunMode RunMode { get; }
 
         /// <inheritdoc/>

--- a/src/Discord.Net.Interactions/Info/Commands/ComponentCommandInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Commands/ComponentCommandInfo.cs
@@ -14,6 +14,9 @@ namespace Discord.Interactions
     public class ComponentCommandInfo : CommandInfo<CommandParameterInfo>
     {
         /// <inheritdoc/>
+        public override CommandTargetType CommandTargetType => CommandTargetType.ButtonInteraction | CommandTargetType.SelectMenuInteraction;
+
+        /// <inheritdoc/>
         public override IReadOnlyCollection<CommandParameterInfo> Parameters { get; }
 
         /// <inheritdoc/>

--- a/src/Discord.Net.Interactions/Info/Commands/ContextCommands/MessageCommandInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Commands/ContextCommands/MessageCommandInfo.cs
@@ -8,6 +8,9 @@ namespace Discord.Interactions
     /// </summary>
     public class MessageCommandInfo : ContextCommandInfo
     {
+        /// <inheritdoc/>
+        public override CommandTargetType CommandTargetType => CommandTargetType.MessageCommand;
+
         internal MessageCommandInfo(Builders.ContextCommandBuilder builder, ModuleInfo module, InteractionService commandService)
             : base(builder, module, commandService) { }
 

--- a/src/Discord.Net.Interactions/Info/Commands/ContextCommands/UserCommandInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Commands/ContextCommands/UserCommandInfo.cs
@@ -8,6 +8,9 @@ namespace Discord.Interactions
     /// </summary>
     public class UserCommandInfo : ContextCommandInfo
     {
+        /// <inheritdoc/>
+        public override CommandTargetType CommandTargetType => CommandTargetType.UserCommand;
+
         internal UserCommandInfo(Builders.ContextCommandBuilder builder, ModuleInfo module, InteractionService commandService)
             : base(builder, module, commandService) { }
 

--- a/src/Discord.Net.Interactions/Info/Commands/ModalCommandInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Commands/ModalCommandInfo.cs
@@ -10,6 +10,9 @@ namespace Discord.Interactions
     /// </summary>
     public class ModalCommandInfo : CommandInfo<ModalCommandParameterInfo>
     {
+        /// <inheritdoc/>
+        public override CommandTargetType CommandTargetType => CommandTargetType.ModalInteraction;
+
         /// <summary>
         ///     Gets the <see cref="ModalInfo"/> class for this commands <see cref="IModal"/> parameter.
         /// </summary>

--- a/src/Discord.Net.Interactions/Info/Commands/SlashCommandInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Commands/SlashCommandInfo.cs
@@ -13,6 +13,9 @@ namespace Discord.Interactions
     /// </summary>
     public class SlashCommandInfo : CommandInfo<SlashCommandParameterInfo>, IApplicationCommandInfo
     {
+        /// <inheritdoc/>
+        public override CommandTargetType CommandTargetType => CommandTargetType.SlashCommand;
+
         /// <summary>
         ///     Gets the command description that will be displayed on Discord.
         /// </summary>

--- a/src/Discord.Net.Interactions/Info/ICommandInfo.cs
+++ b/src/Discord.Net.Interactions/Info/ICommandInfo.cs
@@ -26,6 +26,11 @@ namespace Discord.Interactions
         bool IgnoreGroupNames { get; }
 
         /// <summary>
+        ///     Gets the interaction type this command targets.
+        /// </summary>
+        CommandTargetType CommandTargetType { get; }
+
+        /// <summary>
         ///     Gets wheter this command supports wild card patterns.
         /// </summary>
         bool SupportsWildCards { get; }


### PR DESCRIPTION
This is how i would add an enum to specify the target interaction type of a interaction  service command but i dont know this is a necessary change. `if(ICommandInfo is SlashCommandInfo)` is adequate for most situations